### PR TITLE
add tool for returning account info

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -4,6 +4,7 @@ import {
   transfer_token,
   airdrop_token,
   get_hbar_balance,
+  get_account_info,
   get_hts_balance,
   get_hts_token_details,
   get_all_tokens_balances,
@@ -93,6 +94,11 @@ export default class HederaAgentKit {
       amount,
       this.client
     )
+  }
+
+  async getAccountInfo(accountId?: string): Promise<string | AccountId> {
+    const targetAccountId = accountId || this.client.operatorAccountId;
+    return get_account_info(targetAccountId);
   }
 
   async getHbarBalance(accountId?: string): Promise<number> {

--- a/src/langchain/index.ts
+++ b/src/langchain/index.ts
@@ -151,6 +151,50 @@ amount: number, the amount of tokens to transfer e.g. 100
   }
 }
 
+export class HederaGetAccountInfo extends Tool {
+  name = 'hedera_get_account_info'
+
+  description = `Retreives info about the specified Hedera account.  
+If an account ID is provided, it returns the details of that account.  
+If no input is given (empty JSON '{}'), it returns the details of the connected account.  
+
+### **Inputs** (optional, input is a JSON string):  
+- **accountId** (*string*, optional): The Hedera account ID to get the details for for (e.g., "0.0.789012").  
+  - If omitted, the tool will return the details of the connected account.  
+
+### **Example Usage:**  
+1. **Get account details of a specific account:**  
+   '{ "accountId": "0.0.123456" }'  
+2. **Get account details of the connected account:**  
+   '{}'
+`
+
+
+constructor(private hederaKit: HederaAgentKit) {
+
+    super()
+  }
+
+  protected async _call(input: string): Promise<string> {
+    try {
+      const parsedInput = JSON.parse(input);
+
+      const accountId = await this.hederaKit.getAccountInfo(parsedInput?.accountId);
+
+      return JSON.stringify({
+        status: "success",
+        accountId: accountId,
+      });
+    } catch (error: any) {
+      return JSON.stringify({
+        status: "error",
+        message: error.message,
+        code: error.code || "UNKNOWN_ERROR",
+      });
+    }
+  }
+}
+
 export class HederaGetBalanceTool extends Tool {
   name = 'hedera_get_hbar_balance'
 
@@ -952,6 +996,7 @@ export function createHederaTools(hederaKit: HederaAgentKit): Tool[] {
   return [
     new HederaCreateFungibleTokenTool(hederaKit),
     new HederaTransferTokenTool(hederaKit),
+    new HederaGetAccountInfo(hederaKit),
     new HederaGetBalanceTool(hederaKit),
     new HederaAirdropTokenTool(hederaKit),
     new HederaCreateNonFungibleTokenTool(hederaKit),

--- a/src/tools/hts/queries/balance.ts
+++ b/src/tools/hts/queries/balance.ts
@@ -8,6 +8,16 @@ import {
 import { get_hts_token_details } from "./details";
 import { toDisplayUnit } from "../../../utils/hts-format-utils";
 
+export const get_account_info = async (
+  accountId: string | AccountId | null
+): Promise<string | AccountId> => {
+if(!accountId){
+  throw new Error("accountId must be provided");
+}
+
+return accountId;
+};
+
 export const get_hbar_balance = async (
     client: Client,
     accountId: string | AccountId | null

--- a/src/tools/hts/queries/index.ts
+++ b/src/tools/hts/queries/index.ts
@@ -1,4 +1,4 @@
-export { get_hbar_balance, get_hts_balance, get_all_tokens_balances } from './balance'
+export { get_hbar_balance, get_hts_balance, get_all_tokens_balances, get_account_info } from './balance'
 export { get_hts_token_details } from './details'
 export { get_token_holders } from './holders'
 export { get_pending_airdrops } from './pending_airdrops'


### PR DESCRIPTION
Operator account ID is inherent in the agent context but is not available to LLM. This exposes account ID, which I believe is useful (eg: user asking for their own account ID is very common). Can expand to other account details beyond just ID in the future.

Before:
```
Choose a mode (enter number or name): 1
Starting chat mode... Type 'exit' to end.

Prompt: what's my account info?
I do not have the ability to directly access your account information. However, I can retrieve your HBAR balance or token balances if you would like. Would you like me to get your HBAR balance?

-------------------

Prompt: what's my account id?
I do not have access to your account ID. The account ID is inherent in the Agent's configuration.

-------------------

Prompt: what's my account details?
I do not have the ability to directly access your account details. However, I can retrieve your HBAR balance or token balances if you would like. Would you like me to get your HBAR balance?

-------------------

Prompt: do you have getAccountInfo tool?
No, I do not have a `getAccountInfo` tool.
```

After:
```
Prompt: what's my account info?
[
  { functionCall: { name: 'hedera_get_account_info', args: [Object] } }
]
-------------------
{"status":"success","accountId":{"shard":{"low":0,"high":0,"unsigned":false},"realm":{"low":0,"high":0,"unsigned":false},"num":{"low":5635990,"high":0,"unsigned":false},"aliasKey":null,"evmAddress":null,"_checksum":null}}
-------------------
OK. Your account ID is 0.0.5635990.
-------------------
```