### PR TITLE
LLM layer doesn't allow HBAR transfer to EVM addresses

### DIFF
--- a/src/langchain/index.ts
+++ b/src/langchain/index.ts
@@ -475,12 +475,17 @@ export class HederaTransferHbarTool extends Tool {
 
   description = `Transfer HBAR to an account on Hedera
 Inputs ( input is a JSON string ):
-toAccountId: string, the account ID to transfer to e.g. 0.0.789012,
+toAccountId: string, the account ID to transfer to e.g. 0.0.789012 or EVM address 0x257B2457b10C02d393458393515F51dc8880300d,
 amount: number, the amount of HBAR to transfer e.g. 100,
 Example usage:
 1. Transfer 100 HBAR to account 0.0.789012:
   '{
     "toAccountId": "0.0.789012",
+    "amount": 100
+  }
+2. Transfer 100 HBAR to EVM address 0x257B2457b10C02d393458393515F51dc8880300d:
+  '{
+    "toAccountId": "0x257B2457b10C02d393458393515F51dc8880300d",
     "amount": 100
   }'
 `


### PR DESCRIPTION
Previously would give error that it's not a valid Hedera account ID.

```
Prompt: send 0.5 HBAR to 0x89c0026f4Df5687941759F611defc468040145c4
[ { functionCall: { name: 'hedera_transfer_hbar', args: [Object] } } ]
-------------------
{"toAccountId": "0x89c0026f4Df5687941759F611defc468040145c4", "amount": 0.5}
{"status":"success","message":"HBAR transfer successful","toAccountId":"0x89c0026f4Df5687941759F611defc468040145c4","amount":0.5}
-------------------
OK.
```