### PR TITLE
docs: add quickstart for langchain and langgraph

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -2,7 +2,7 @@
 Provide a concise summary of the feature, task, or bug to be addressed. Highlight its purpose and importance within the overall project.
 
 **Roadmap Reference:**
-[ROADMAP.md > Native Hedera Token Service > Mint Token](https://github.com/jaycoolh/hedera-agent-kit/blob/main/ROADMAP.md)
+[ROADMAP.md > Native Hedera Token Service > Mint Token](https://github.com/hedera-dev/hedera-agent-kit/blob/main/ROADMAP.md)
 
 **Proposed Implementation/Tasks:**
 - [ ] Task 1: Brief description of the task.
@@ -20,9 +20,9 @@ Include any other relevant details or links, such as:
 - Example input/output (if applicable).
 - Known challenges or limitations.
 
-**Labels:** 
-`feature` (or `bug`, `enhancement`, etc.)  
-`area-label` (e.g., `token-service`, `consensus-service`, `dex-swaps`)  
+**Labels:**
+`feature` (or `bug`, `enhancement`, etc.)
+`area-label` (e.g., `token-service`, `consensus-service`, `dex-swaps`)
 `good-first-issue` (if applicable for beginners)
 
 **Milestone:** [Milestone Name or Version Number]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ We are thrilled that you’re interested in contributing to the **Hedera Agent K
 2. **Clone** your fork:
 
 ```bash
-  git clone https://github.com/jaycoolh/hedera-agent-kit.git
+  git clone https://github.com/hedera-dev/hedera-agent-kit.git
 ```
 
 3. Create a new branch for your work:

--- a/README.md
+++ b/README.md
@@ -56,12 +56,32 @@ For further details check [HederaAgentKit Readme](./src/agent/README.md).
 npm i hedera-agent-kit
 ```
 
-or
+LangChain/ LangGraph quick start:
+
+```js
+import { HederaAgentKit, createHederaTools } from 'hedera-agent-kit';
+import { ToolNode } from '@langchain/langgraph/prebuilt';
+
+const hederaAgentKit = new HederaAgentKit(
+  '0.0.12345', // Replace with your account ID
+  '0x.......', // Replace with your private key
+  'testnet',   // Replace with your selected network
+);
+const hederaAgentKitTools = createHederaTools(hederaAgentKit);
+const toolsNode = new ToolNode(tools);
+
+```
+- `hederaAgentKitTools` is an array of `Tool` instances
+  (from `@langchain/core/tools`).
+- `toolsNode` can be used in any LangGraph workflow,
+  for example `workflow.addNode('toolsNode', toolsNode)`.
+
+## Local development
 
 1. **Clone** the repo:
 
 ```bash
-git clone https://github.com/jaycoolh/hedera-agent-kit.git
+git clone https://github.com/hedera-dev/hedera-agent-kit.git
 ```
 
 2. Install dependencies:


### PR DESCRIPTION
## Description

- Adds a quickstart for langchain and langgraph into the main README
- Also updates the URLs in various markdown files

## Related Issue

- Fixes https://github.com/hedera-dev/hedera-agent-kit/issues/22

## Checklist

- [ ] My code follows the contributing guidelines of this project. -> N/A
- [ ] I have performed a self-review of my code.-> N/A
- [x] My commits are DCO-signed (`git commit -s`).
- [ ] I have commented my code where needed, particularly in hard-to-understand areas.-> N/A
- [ ] I have added tests to prove my fix is effective or that my feature works.-> N/A
