### PR TITLE
Rename operational modes for clarity

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -65,7 +65,7 @@ export class HederaAgentKit {
   constructor(
     signer: AbstractSigner,
     pluginConfigInput?: PluginConfig | undefined,
-    initialOperationalMode: AgentOperationalMode = 'provideBytes',
+    initialOperationalMode: AgentOperationalMode = 'human-in-the-loop',
     userAccountId?: string,
     scheduleUserTransactionsInBytesMode: boolean = true,
     modelCapability: ModelCapability = ModelCapability.MEDIUM,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,7 +47,7 @@ export {
   ScheduleId,
 };
 
-export type AgentOperationalMode = 'directExecution' | 'provideBytes';
+export type AgentOperationalMode = 'human-in-the-loop' | 'autonomous' | 'directExecution' | 'provideBytes';
 export type HederaNetworkType = 'mainnet' | 'testnet';
 
 /**


### PR DESCRIPTION
Operational mode naming was updated for clarity. The `'provideBytes'` mode is now `'human-in-the-loop'`, and `'directExecution'` is now `'autonomous'`.

To ensure backward compatibility while guiding new usage:
*   The `AgentOperationalMode` type in `src/types/index.ts` was expanded to include both the new (`'human-in-the-loop'`, `'autonomous'`) and legacy (`'directExecution'`, `'provideBytes'`) string literals. This allows existing code to continue functioning.
*   The default `initialOperationalMode` in the `HederaAgentKit` constructor in `src/agent/agent.ts` was changed from `'provideBytes'` to `'human-in-the-loop'`.
*   The `README.md` was extensively updated. All code examples, explanations, and headings now use the new naming conventions, with explicit mentions of the legacy names for clarity.

This change improves readability and intuitiveness, clearly distinguishing between modes requiring user interaction and autonomous operation, while ensuring type recommendations prioritize the new names.