### PR TITLE
fix: bugs in tools schemas and descriptions

### DIFF
--- a/typescript/src/plugins/core-account-plugin/tools/account/transfer-hbar.ts
+++ b/typescript/src/plugins/core-account-plugin/tools/account/transfer-hbar.ts
@@ -22,10 +22,11 @@ ${contextSnippet}
 This tool will transfer HBAR to an account.
 
 Parameters:
-- hbarAmount (number, required): Amount of HBAR to transfer
-- destinationAccountId (str, required): Account to transfer HBAR to
+- transfers (array of objects, required): List of HBAR transfers. Each object should contain:
+  - accountId (string): Recipient account ID
+  - amount (number): Amount of HBAR to transfer
 - ${sourceAccountDesc}
-- transactionMemo (str, optional): Optional memo for the transaction
+- transactionMemo (string, optional): Optional memo for the transaction
 ${usageInstructions}
 `;
 };

--- a/typescript/src/shared/parameter-schemas/hts.zod.ts
+++ b/typescript/src/shared/parameter-schemas/hts.zod.ts
@@ -73,7 +73,6 @@ const AirdropRecipientSchema = z.object({
 export const airdropFungibleTokenParameters = (_context: Context = {}) =>
   z.object({
     tokenId: z.string().describe('The id of the token.'),
-    amount: z.number().describe('The amount of tokens to airdrop.'),
     sourceAccountId: z.string().optional().describe('The account to airdrop the token from.'),
     recipients: z
       .array(AirdropRecipientSchema)


### PR DESCRIPTION
References: #134 
Fixes unnecessary field in `airdrop_fungible_token_tool` zod schema and fixes description of `transfer_hbar_tool` to match the expected Zod schema