### PR TITLE
feat: add token info query action

### DIFF
--- a/typescript/examples/langchain/package-lock.json
+++ b/typescript/examples/langchain/package-lock.json
@@ -13,7 +13,7 @@
         "@langchain/core": "^0.3.66",
         "@langchain/openai": "^0.6.2",
         "dotenv": "^17.2.0",
-        "hedera-agent-kit": "3.0.7",
+        "hedera-agent-kit": "../..",
         "langchain": "^0.3.30",
         "prompts": "^2.4.2"
       },

--- a/typescript/examples/langchain/plugin-tool-calling-agent.ts
+++ b/typescript/examples/langchain/plugin-tool-calling-agent.ts
@@ -33,6 +33,7 @@ async function bootstrap(): Promise<void> {
 
   const {
     GET_HBAR_BALANCE_QUERY_TOOL,
+    GET_TOKEN_INFO_QUERY_TOOL,
   } = coreQueriesPluginToolNames;
 
 
@@ -46,6 +47,7 @@ async function bootstrap(): Promise<void> {
         SUBMIT_TOPIC_MESSAGE_TOOL,
         CREATE_FUNGIBLE_TOKEN_TOOL,
         GET_HBAR_BALANCE_QUERY_TOOL,
+        GET_TOKEN_INFO_QUERY_TOOL,
         // Plugin tools
         'example_greeting_tool',
         'example_hbar_transfer_tool',

--- a/typescript/src/plugins/core-queries-plugin/index.ts
+++ b/typescript/src/plugins/core-queries-plugin/index.ts
@@ -12,6 +12,7 @@ import getAccountTokenBalancesQuery, {
 import getTopicMessagesQuery, {
   GET_TOPIC_MESSAGES_QUERY_TOOL,
 } from '@/plugins/core-queries-plugin/tools/queries/get-topic-messages-query';
+import getTokenInfoQuery, { GET_TOKEN_INFO_QUERY_TOOL}  from '@/plugins/core-queries-plugin/tools/queries/get-token-info-query';
 
 export const coreQueriesPlugin: Plugin = {
   name: 'core-queries-plugin',
@@ -23,6 +24,7 @@ export const coreQueriesPlugin: Plugin = {
       getAccountQuery(context),
       getAccountTokenBalancesQuery(context),
       getTopicMessagesQuery(context),
+      getTokenInfoQuery(context)
     ];
   },
 };
@@ -32,6 +34,7 @@ export const coreQueriesPluginToolNames = {
   GET_ACCOUNT_QUERY_TOOL,
   GET_ACCOUNT_TOKEN_BALANCES_QUERY_TOOL,
   GET_TOPIC_MESSAGES_QUERY_TOOL,
+  GET_TOKEN_INFO_QUERY_TOOL
 } as const;
 
 export default { coreQueriesPlugin, coreQueriesPluginToolNames };

--- a/typescript/src/plugins/core-queries-plugin/tools/queries/get-account-query.ts
+++ b/typescript/src/plugins/core-queries-plugin/tools/queries/get-account-query.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { Client } from '@hashgraph/sdk';
 import { Context } from '@/shared/configuration';
 import { getMirrornodeService } from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-utils';
-import { accountQueryParameters } from '@/shared/parameter-schemas/account-query.zod';
+import { accountQueryParameters } from '@/shared/parameter-schemas/query.zod';
 import { Tool } from '@/shared/tools';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';
 import { AccountResponse } from '@/shared/hedera-utils/mirrornode/types';
@@ -52,7 +52,7 @@ export const getAccountQuery = async (
 
 export const GET_ACCOUNT_QUERY_TOOL = 'get_account_query_tool';
 
-const getAccountQueryTool = (context: Context): Tool => ({
+const tool = (context: Context): Tool => ({
   method: GET_ACCOUNT_QUERY_TOOL,
   name: 'Get Account Query',
   description: getAccountQueryPrompt(context),
@@ -60,4 +60,4 @@ const getAccountQueryTool = (context: Context): Tool => ({
   execute: getAccountQuery,
 });
 
-export default getAccountQueryTool;
+export default tool;

--- a/typescript/src/plugins/core-queries-plugin/tools/queries/get-account-token-balances-query.ts
+++ b/typescript/src/plugins/core-queries-plugin/tools/queries/get-account-token-balances-query.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { Context } from '@/shared/configuration';
 import { getMirrornodeService } from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-utils';
-import { accountTokenBalancesQueryParameters } from '@/shared/parameter-schemas/account-query.zod';
+import { accountTokenBalancesQueryParameters } from '@/shared/parameter-schemas/query.zod';
 import { Client } from '@hashgraph/sdk';
 import { Tool } from '@/shared/tools';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';

--- a/typescript/src/plugins/core-queries-plugin/tools/queries/get-hbar-balance-query.ts
+++ b/typescript/src/plugins/core-queries-plugin/tools/queries/get-hbar-balance-query.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
 import type { Tool } from '@/shared/tools';
 import { Client } from '@hashgraph/sdk';
-import { accountBalanceQueryParameters } from '@/shared/parameter-schemas/account-query.zod';
+import { accountBalanceQueryParameters } from '@/shared/parameter-schemas/query.zod';
 import BigNumber from 'bignumber.js';
 import { getMirrornodeService } from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-utils';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';

--- a/typescript/src/plugins/core-queries-plugin/tools/queries/get-token-info-query.ts
+++ b/typescript/src/plugins/core-queries-plugin/tools/queries/get-token-info-query.ts
@@ -1,0 +1,107 @@
+import { z } from 'zod';
+import { Context } from '@/shared/configuration';
+import { getMirrornodeService } from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-utils';
+import { tokenInfoQueryParameters } from '@/shared/parameter-schemas/query.zod';
+import { Client } from '@hashgraph/sdk';
+import { Tool } from '@/shared/tools';
+import { PromptGenerator } from '@/shared/utils/prompt-generator';
+import { TokenInfo } from '@/shared/hedera-utils/mirrornode/types';
+
+export const getTokenInfoQueryPrompt = (context: Context = {}) => {
+  const contextSnippet = PromptGenerator.getContextSnippet(context);
+  const usageInstructions = PromptGenerator.getParameterUsageInstructions();
+
+  return `
+${contextSnippet}
+
+This tool will return the information for a given Hedera token.
+
+Parameters:
+- tokenId (str): The token ID to query for.
+${usageInstructions}
+`;
+};
+
+const postProcess = (tokenInfo: TokenInfo) => {
+  const formatSupply = (supply?: string) => {
+    if (!supply) return 'N/A';
+
+    const decimals = Number(tokenInfo.decimals || '0');
+    const amount = Number(supply);
+    if (isNaN(amount)) return supply;
+
+    return (amount / 10 ** decimals).toLocaleString();
+  };
+
+
+  const formatKey = (key?: { _type: string; key: string } | null) => {
+    if (!key) return 'Not Set';
+    return key._type ? `${key.key}` : 'Present';
+  };
+
+  const supplyType = tokenInfo.supply_type === 'INFINITE' ? 'Infinite' : tokenInfo.max_supply || 'Finite';
+  const freezeStatus = tokenInfo.freeze_default ? 'Frozen' : 'Active';
+
+  return `Here are the details for token **${tokenInfo.token_id}**:
+
+- **Token Name**: ${tokenInfo.name}
+- **Token Symbol**: ${tokenInfo.symbol}
+- **Token Type**: ${tokenInfo.type || 'N/A'}
+- **Decimals**: ${tokenInfo.decimals}
+- **Max Supply**: ${formatSupply(tokenInfo.max_supply)}
+- **Current Supply**: ${formatSupply(tokenInfo.total_supply)}
+- **Supply Type**: ${supplyType}
+- **Treasury Account ID**: ${tokenInfo.treasury_account_id || 'N/A'}
+- **Status (Deleted/Active)**: ${tokenInfo.deleted ? 'Deleted' : 'Active'}
+- **Status (Frozen/Active)**: ${freezeStatus}
+
+**Keys**:
+- Admin Key: ${formatKey(tokenInfo.admin_key)}
+- Supply Key: ${formatKey(tokenInfo.supply_key)}
+- Wipe Key: ${formatKey(tokenInfo.wipe_key)}
+- KYC Key: ${formatKey(tokenInfo.kyc_key)}
+- Freeze Key: ${formatKey(tokenInfo.freeze_key)}
+- Fee Schedule Key: ${formatKey(tokenInfo.fee_schedule_key)}
+- Pause Key: ${formatKey(tokenInfo.pause_key)}
+- Metadata Key: ${formatKey(tokenInfo.metadata_key)}
+
+${tokenInfo.memo ? `**Memo**: ${tokenInfo.memo}` : ''}
+`;
+};
+
+export const getTokenInfoQuery = async (
+  client: Client,
+  context: Context,
+  params: z.infer<ReturnType<typeof tokenInfoQueryParameters>>,
+) => {
+  try {
+    const mirrornodeService = getMirrornodeService(context.mirrornodeService!, client.ledgerId!);
+    const tokenInfo: TokenInfo = {
+      ...(await mirrornodeService.getTokenInfo(params.tokenId!)),
+      token_id: params.tokenId!,
+    };
+
+    return {
+      raw: { tokenId: params.tokenId, tokenInfo },
+      humanMessage: postProcess(tokenInfo),
+    };
+  } catch (error) {
+    console.error('Error getting token info', error);
+    if (error instanceof Error) {
+      return error.message;
+    }
+    return 'Failed to get token info';
+  }
+};
+
+export const GET_TOKEN_INFO_QUERY_TOOL = 'get_token_info_query_tool';
+
+const tool = (context: Context): Tool => ({
+  method: GET_TOKEN_INFO_QUERY_TOOL,
+  name: 'Get Token Info',
+  description: getTokenInfoQueryPrompt(context),
+  parameters: tokenInfoQueryParameters(context),
+  execute: getTokenInfoQuery,
+});
+
+export default tool;

--- a/typescript/src/plugins/core-queries-plugin/tools/queries/get-topic-messages-query.ts
+++ b/typescript/src/plugins/core-queries-plugin/tools/queries/get-topic-messages-query.ts
@@ -1,6 +1,6 @@
 import { Context } from '@/shared/configuration';
 import { getMirrornodeService } from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-utils';
-import { topicMessagesQueryParameters } from '@/shared/parameter-schemas/account-query.zod';
+import { topicMessagesQueryParameters } from '@/shared/parameter-schemas/query.zod';
 import { Client } from '@hashgraph/sdk';
 import { z } from 'zod';
 import { Tool } from '@/shared/tools';

--- a/typescript/src/shared/hedera-utils/hedera-parameter-normaliser.ts
+++ b/typescript/src/shared/hedera-utils/hedera-parameter-normaliser.ts
@@ -21,7 +21,7 @@ import z from 'zod';
 import {
   accountBalanceQueryParameters,
   accountTokenBalancesQueryParameters,
-} from '@/shared/parameter-schemas/account-query.zod';
+} from '@/shared/parameter-schemas/query.zod';
 import { IHederaMirrornodeService } from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-service.interface';
 import { toBaseUnit } from '@/shared/hedera-utils/decimals-utils';
 import Long from 'long';
@@ -171,8 +171,8 @@ export default class HederaParameterNormaliser {
   ) {
     const sourceAccountId = AccountResolver.resolveAccount(params.sourceAccountId, context, client);
 
-    const tokenDetails = await mirrorNode.getTokenDetails(params.tokenId);
-    const tokenDecimals = parseInt(tokenDetails.decimals, 10);
+    const tokenInfo = await mirrorNode.getTokenInfo(params.tokenId);
+    const tokenDecimals = parseInt(tokenInfo.decimals, 10);
 
     const tokenTransfers: TokenTransferMinimalParams[] = [];
     let totalAmount = Long.ZERO;
@@ -285,11 +285,11 @@ export default class HederaParameterNormaliser {
 
   static async normaliseMintFungibleTokenParams(
     params: z.infer<ReturnType<typeof mintFungibleTokenParameters>>,
-    context: Context,
+    _context: Context,
     mirrorNode: IHederaMirrornodeService,
   ) {
     const decimals =
-      (await mirrorNode.getTokenDetails(params.tokenId).then(r => Number(r.decimals))) ?? 0;
+      (await mirrorNode.getTokenInfo(params.tokenId).then(r => Number(r.decimals))) ?? 0;
     const baseAmount = toBaseUnit(params.amount, decimals);
     return {
       tokenId: params.tokenId,

--- a/typescript/src/shared/hedera-utils/mirrornode/hedera-mirrornode-service-default-impl.ts
+++ b/typescript/src/shared/hedera-utils/mirrornode/hedera-mirrornode-service-default-impl.ts
@@ -5,7 +5,7 @@ import {
   AccountResponse,
   LedgerIdToBaseUrl,
   TokenBalancesResponse,
-  TokenDetails,
+  TokenInfo,
   TopicMessage,
   TopicMessagesAPIResponse,
   TopicMessagesQueryParams,
@@ -96,7 +96,7 @@ export class HederaMirrornodeServiceDefaultImpl implements IHederaMirrornodeServ
     };
   }
 
-  async getTokenDetails(tokenId: string): Promise<TokenDetails> {
+  async getTokenInfo(tokenId: string): Promise<TokenInfo> {
     const url = `${this.baseUrl}/tokens/${tokenId}`;
     const response = await fetch(url);
     return await response.json();

--- a/typescript/src/shared/hedera-utils/mirrornode/hedera-mirrornode-service.interface.ts
+++ b/typescript/src/shared/hedera-utils/mirrornode/hedera-mirrornode-service.interface.ts
@@ -4,7 +4,7 @@ import {
   AccountResponse,
   TokenBalancesResponse,
   TopicMessagesResponse,
-  TokenDetails,
+  TokenInfo,
 } from './types';
 
 export interface IHederaMirrornodeService {
@@ -12,5 +12,5 @@ export interface IHederaMirrornodeService {
   getAccountHBarBalance(accountId: string): Promise<BigNumber>;
   getAccountTokenBalances(accountId: string): Promise<TokenBalancesResponse>;
   getTopicMessages(queryParams: TopicMessagesQueryParams): Promise<TopicMessagesResponse>;
-  getTokenDetails(tokenId: string): Promise<TokenDetails>;
+  getTokenInfo(tokenId: string): Promise<TokenInfo>;
 }

--- a/typescript/src/shared/hedera-utils/mirrornode/types.ts
+++ b/typescript/src/shared/hedera-utils/mirrornode/types.ts
@@ -1,4 +1,4 @@
-import { LedgerId, TokenType } from '@hashgraph/sdk';
+import { LedgerId } from '@hashgraph/sdk';
 import BigNumber from 'bignumber.js';
 
 export const LedgerIdToBaseUrl: Map<string, string> = new Map([
@@ -69,10 +69,78 @@ export type TopicMessagesAPIResponse = {
 
 export type KeyEncryptionType = 'ED25519' | 'ECDSA_SECP256K1';
 
-export type TokenDetails = {
-  decimals: string;
+/**
+ * This type matches responses from Hedera Mirror Node API
+ */
+export type TokenInfo = {
+  // Basic Token Identity
+  token_id?: string;
   name: string;
   symbol: string;
-  maxSupply: number;
-  type: TokenType;
+  type?: string;
+  memo?: string;
+
+  // Supply Information
+  decimals: string;
+  initial_supply?: string;
+  total_supply?: string;
+  max_supply?: string;
+  supply_type?: string;
+
+  // Account & Treasury
+  treasury_account_id?: string;
+  auto_renew_account?: string;
+  auto_renew_period?: number;
+
+  // Status & State
+  deleted: boolean;
+  freeze_default?: boolean;
+  pause_status?: string;
+
+  // Timestamps
+  created_timestamp?: string;
+  modified_timestamp?: string;
+  expiry_timestamp?: number;
+
+  // Keys
+  admin_key?: {
+    _type: string;
+    key: string;
+  } | null;
+  supply_key?: {
+    _type: string;
+    key: string;
+  } | null;
+  kyc_key?: {
+    _type: string;
+    key: string;
+  } | null;
+  freeze_key?: {
+    _type: string;
+    key: string;
+  } | null;
+  wipe_key?: {
+    _type: string;
+    key: string;
+  } | null;
+  pause_key?: {
+    _type: string;
+    key: string;
+  } | null;
+  fee_schedule_key?: {
+    _type: string;
+    key: string;
+  } | null;
+  metadata_key?: {
+    _type: string;
+    key: string;
+  } | null;
+
+  // Metadata & Custom Features
+  metadata?: string;
+  custom_fees?: {
+    created_timestamp: string;
+    fixed_fees: any[];
+    fractional_fees: any[];
+  };
 };

--- a/typescript/src/shared/parameter-schemas/query.zod.ts
+++ b/typescript/src/shared/parameter-schemas/query.zod.ts
@@ -23,6 +23,11 @@ export const accountTokenBalancesQueryParameters = (_context: Context = {}) =>
     tokenId: z.string().optional().describe('The token ID to query.'),
   });
 
+export const tokenInfoQueryParameters = (_context:Context = {}) =>
+  z.object({
+    tokenId: z.string().optional().describe('The token ID to query.'),
+  })
+
 export const topicMessagesQueryParameters = (_context: Context = {}) =>
   z.object({
     topicId: z.string().describe('The topic ID to query.'),


### PR DESCRIPTION
This PR references #168.
Changes:
- new action added - `CREATE_FUNGIBLE_TOKEN_TOOL`
- directory within `core-queries-plugin` renamed from `account-queries` to just `queries` as currently in addition to account related tools it contains topic and token query tools